### PR TITLE
Fix/preview caching

### DIFF
--- a/stylist/__version__.py
+++ b/stylist/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "0.1.5"
+VERSION = "0.1.6"

--- a/stylist/tests.py
+++ b/stylist/tests.py
@@ -129,7 +129,7 @@ class StylistClientTests(TestCase):
             data = style.attrs
             data["name"] = style.name
             response = self.client.post(url, data, follow=True)
-            self.assertEquals(response.context["preview_style"], settings.MEDIA_URL + "site/" + site.domain + "/style/Test_preview.css")
+            self.assertIn(settings.MEDIA_URL + "site/" + site.domain + "/style/Test_preview.css", response.context["preview_style"])
 
             # cleanup preview file
             path = self.client.session["preview_path"]


### PR DESCRIPTION
* Bust cache to always use the most recent preview file
* If preview mode is currently active when creating a new preview, delete the old file (updated to not be dependent on name)