### PR TITLE
Rename var to STYLIST_USE_SASS

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ If you just need the model to store style values: `pip install django-stylist`
 
 ## Upgrading from from 0.1.x
 
-Legacy users should add the setting STYLIST_IGNORE_SASS = False should they choose to continue compiling sass files.
+Legacy users should add the setting STYLIST_USE_SASS = True should they choose to continue compiling sass files.

--- a/develop/develop/settings.py
+++ b/develop/develop/settings.py
@@ -148,7 +148,7 @@ MEDIA_URL = "/media/"
 # STYLIST_DEFAULT_CSS = STATIC_URL + "css/default.css"
 STYLIST_DEFAULT_CSS = os.path.join(MEDIA_ROOT, "css/default.css")
 STYLIST_SCSS_TEMPLATE = os.path.join(BASE_DIR, "scss/base_template.scss")
-STYLIST_IGNORE_SASS = True
+
 STYLE_SCHEMA = {
     "primary": {
         "type": "color",

--- a/stylist/admin.py
+++ b/stylist/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
-from django.conf import settings
 
 from .models import Style
+from .settings import app_settings
 
 
 def compile_styles(modeladmin, request, queryset):
@@ -17,7 +17,7 @@ class StyleAdmin(admin.ModelAdmin):
     
     def __init__(self, model=Style, admin_site=admin.site) -> None:
         super().__init__(model, admin_site)
-        if not getattr(settings, 'STYLIST_IGNORE_SASS', True):
+        if app_settings.USE_SASS:
             self.actions.append(compile_styles)
 
 admin.site.register(Style, StyleAdmin)

--- a/stylist/api/views.py
+++ b/stylist/api/views.py
@@ -5,6 +5,7 @@ from django.shortcuts import redirect
 
 from stylist.models import Style 
 from stylist.api.serializers import StyleSerializer
+from stylist.settings import app_settings
 
 
 class StyleCreateAPIView(CreateAPIView):
@@ -17,7 +18,7 @@ class StyleCreateAPIView(CreateAPIView):
           else:
                site = Site.objects.get_current()
           instance = serializer.save(site=site)
-          if not getattr(settings, 'STYLIST_IGNORE_SASS', True):
+          if app_settings.USE_SASS:
                instance.compile_attrs()
 
           if not Style.objects.filter(site=site, enabled=True):
@@ -41,7 +42,7 @@ class StyleDuplicateAPIView(CreateAPIView):
                site = Site.objects.get_current()
           new_name = previous.name + " copy"
           instance = serializer.save(site=site, attrs=previous.attrs, name=new_name)
-          if not getattr(settings, 'STYLIST_IGNORE_SASS', True):
+          if app_settings.USE_SASS:
                instance.compile_attrs()
 
           if not Style.objects.filter(site=site, enabled=True):

--- a/stylist/context_processors.py
+++ b/stylist/context_processors.py
@@ -2,6 +2,7 @@ from django.contrib.sites.models import Site
 from django.conf import settings
 
 from .models import Style
+from .settings import app_settings
 
 def add_rgb_colors(css_attrs):
      ## adds rgb values for all colors
@@ -31,26 +32,25 @@ def get_custom_styles(request):
         
     try:
         style = Style.objects.filter(site=site).get(enabled=True)
-        if getattr(settings, 'STYLIST_IGNORE_SASS', True):
-            css_attrs = Style.objects.filter(site=site).get(enabled=True).attrs
-            custom_style = add_rgb_colors(css_attrs)
-            custom_font_import = get_font_families(css_attrs)
-        else:
+        if app_settings.USE_SASS:
             custom_style = style.css_file.url
             custom_font_import = None
-
+        else:
+            css_attrs = style.attrs
+            custom_style = add_rgb_colors(css_attrs)
+            custom_font_import = get_font_families(css_attrs)
         
     except:
         custom_style = None
         custom_font_import = None
     try:
-        if getattr(settings, 'STYLIST_IGNORE_SASS', True):
+        if app_settings.USE_SASS:
+            preview_style = request.session.get("preview_css")
+            preview_font_import = None
+        else:
             css_attrs = request.session.get("preview_css")
             preview_style = add_rgb_colors(css_attrs)
             preview_font_import = get_font_families(css_attrs)
-        else:
-            preview_style = request.session.get("preview_css")
-            preview_font_import = None
     except:
         preview_style = None
         preview_font_import = None

--- a/stylist/forms.py
+++ b/stylist/forms.py
@@ -2,10 +2,10 @@ import re
 
 from django import forms
 from django.conf import settings
-from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError, ImproperlyConfigured
 
-from stylist.models import Style
+from .models import Style
+from .settings import app_settings
 
 class StyleForm(forms.ModelForm):
 
@@ -67,11 +67,11 @@ class StyleEditForm(forms.ModelForm):
                 elif settings.STYLE_SCHEMA[key]["type"] == "px":
                     self.clean_px(key)
         
-        if not getattr(settings, 'STYLIST_IGNORE_SASS', True):
+        if app_settings.USE_SASS:
             try:
                 import sass
             except ModuleNotFoundError as err:
-                self.add_error(None, ImproperlyConfigured("Improperly Configured: Please reinstall django-stylist with `pip install django-stylist[sass]`"))
+                self.add_error(None, ImproperlyConfigured("Improperly Configured: Please reinstall django-stylist with `pip install django-stylist[sass]` to add sass support"))
 
         return cleaned_data
 
@@ -134,6 +134,6 @@ class StyleEditForm(forms.ModelForm):
                     instance.attrs[field] = self.cleaned_data[field]
             if len(self.changed_data) > 1 or self.changed_data[0] != "name":
                 instance.save()
-                if not getattr(settings, 'STYLIST_IGNORE_SASS', True):
+                if app_settings.USE_SASS:
                     instance.compile_attrs()
         return instance

--- a/stylist/management/commands/build_scss.py
+++ b/stylist/management/commands/build_scss.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
         try:
             import sass
         except ModuleNotFoundError as err:
-            raise Exception("Please reinstall django-stylist with `pip install django-stylist[sass]`") from err
+            raise Exception("Please reinstall django-stylist with `pip install django-stylist[sass]` to add sass support") from err
         
         custom_vars = build_scss(self, data)
         

--- a/stylist/models.py
+++ b/stylist/models.py
@@ -71,7 +71,7 @@ class Style(models.Model):
         try:
             import sass
         except ModuleNotFoundError as err:
-            raise ImproperlyConfigured("Please reinstall django-stylist with `pip install django-stylist[sass]`") from err
+            raise ImproperlyConfigured("Please reinstall django-stylist with `pip install django-stylist[sass]` to add sass support") from err
             
         with open(gettempdir() + "/custom_vars.scss", "w+") as custom_vars:
             string = ""

--- a/stylist/settings.py
+++ b/stylist/settings.py
@@ -1,0 +1,17 @@
+from django.conf import settings
+
+class AppSettings(object):
+
+    def __init__(self, prefix):
+        self.prefix = prefix
+
+    def _setting(self, name, default):
+        return getattr(settings, self.prefix + name, default)
+
+    @property
+    def USE_SASS(self):
+        """ Category choices for a support request ticket """
+        return self._setting('USE_SASS', False)
+
+
+app_settings = AppSettings('STYLIST_')

--- a/stylist/tests.py
+++ b/stylist/tests.py
@@ -38,7 +38,7 @@ class ModuleTests(TestCase):
             except:
                 self.fail("\n\nHey, There are missing migrations!\n\n %s" % output.getvalue())
 
-@override_settings(STYLIST_IGNORE_SASS=False)
+@override_settings(STYLIST_USE_SASS=True)
 class StylistClientTests(TestCase):
     '''
     Client tests for Stylist and the Style model
@@ -111,7 +111,7 @@ class StylistClientTests(TestCase):
             data["primary"] = "#FF0000"
             response = self.client.post(url, data, follow=True)
 
-            self.assertContains(response, "Improperly Configured: Please reinstall django-stylist with `pip install django-stylist[sass]`")
+            self.assertContains(response, "Improperly Configured: Please reinstall django-stylist with `pip install django-stylist[sass]` to add sass support")
             
         except:
             print("")
@@ -209,7 +209,7 @@ class StylistClientTests(TestCase):
             print(response.content.decode('utf-8'))
             raise
 
-@override_settings(STYLIST_IGNORE_SASS=False)
+@override_settings(STYLIST_USE_SASS=True)
 class StylistModelTests(TestCase):
 
     @patch('builtins.__import__', side_effect=import_mock)

--- a/stylist/views.py
+++ b/stylist/views.py
@@ -15,6 +15,7 @@ from tempfile import gettempdir
 
 from .forms import StyleForm, StyleEditForm, ActiveStyleForm
 from .models import Style, css_file_path
+from .settings import app_settings
 
 def build_scss(self, data = {}):
     with open(gettempdir() + "/custom_vars.scss", "w+") as custom_vars:
@@ -77,9 +78,7 @@ class StylistPreviewView(LoginRequiredMixin, FormView):
         return context
 
     def form_valid(self, form):
-        if getattr(settings, 'STYLIST_IGNORE_SASS', True):
-            self.request.session["preview_css"] = form.cleaned_data
-        else:
+        if app_settings.USE_SASS:
             import sass
             
             custom_vars = build_scss(self, form.cleaned_data)
@@ -98,7 +97,8 @@ class StylistPreviewView(LoginRequiredMixin, FormView):
             self.request.session["preview_css"] = default_storage.url(preview) + timestamp
             self.request.session["preview_path"] = preview
             os.remove(custom_vars.name)
-        
+        else:
+            self.request.session["preview_css"] = form.cleaned_data
         return redirect(self.get_success_url())
 
 


### PR DESCRIPTION
Based on feedback from @renderbox:
* Rename optional SASS setting to STYLIST_USE_SASS
* Create an app settings file to set the default value
* Update error messages to be a bit more clear