### PR TITLE
Use spaces for rgb colors instead of commas

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
             'django-allauth',
             'django-extensions',
             'djangorestframework',
+            'requests'
         ],
         'test': ['libsass'],                         # Packages needed to run tests
         'prod': [],                         # Packages needed to run in the deployment

--- a/stylist/__version__.py
+++ b/stylist/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "0.2.1"
+VERSION = "0.2.3"

--- a/stylist/context_processors.py
+++ b/stylist/context_processors.py
@@ -9,7 +9,7 @@ def add_rgb_colors(css_attrs):
      for key, value in settings.STYLE_SCHEMA.items():
          if value['type'] == 'color':
              hex = css_attrs[key].lstrip("#")
-             css_attrs[f"{key}-rgb"] = ",".join(tuple(str(int(hex[i:i+2], 16)) for i in (0, 2, 4)))
+             css_attrs[f"{key}-rgb"] = " ".join(tuple(str(int(hex[i:i+2], 16)) for i in (0, 2, 4)))
      return css_attrs
 
 def get_font_families(css_attrs):


### PR DESCRIPTION
so you can use `rgb(var(--name))` without transforming the data
also adds requests package to the setup file to resolve test error