### PR TITLE
Requests requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     install_requires=[
         'Django>=3.0',
         'django-autoslug',
+        'requests',
     ],
     extras_require={
         'sass': [
@@ -57,7 +58,6 @@ setup(
             'django-allauth',
             'django-extensions',
             'djangorestframework',
-            'requests',
         ],
         'test': ['libsass'],                         # Packages needed to run tests
         'prod': [],                         # Packages needed to run in the deployment

--- a/stylist/__version__.py
+++ b/stylist/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "0.2.3"
+VERSION = "0.2.4"


### PR DESCRIPTION
Move `requests` requirement to `install_requires` to avoid errors when using django admin